### PR TITLE
feat: implement external file access request functionality and fix #

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,8 +133,8 @@ importers:
         specifier: ^3.0.5
         version: 3.2.0
       '@types/node':
-        specifier: ^22.10.2
-        version: 22.20.1
+        specifier: ^24.0.0
+        version: 24.13.3
       '@types/pdf-parse':
         specifier: ^1.1.5
         version: 1.1.5
@@ -155,7 +155,7 @@ importers:
         version: 1.15.5
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.3(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0))
+        version: 6.0.3(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.10(vitest@4.1.10)
@@ -272,13 +272,13 @@ importers:
         version: 4.4.1
       vite:
         specifier: ^8.0.16
-        version: 8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0)
+        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0)
       vite-plugin-electron:
         specifier: ^0.28.8
         version: 0.28.8
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0))
       vscode-langservers-extracted:
         specifier: ^4.10.0
         version: 4.10.0
@@ -1173,6 +1173,9 @@ packages:
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
   '@types/pdf-parse@1.1.5':
     resolution: {integrity: sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==}
 
@@ -1347,6 +1350,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xterm/addon-fit@0.10.0':
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
@@ -3712,6 +3716,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   undici@6.28.0:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
@@ -4728,13 +4735,13 @@ snapshots:
 
   '@types/adm-zip@0.5.8':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
 
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
       '@types/responselike': 1.0.3
 
   '@types/chai@5.2.3':
@@ -4764,7 +4771,7 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
 
   '@types/hast@3.0.5':
     dependencies:
@@ -4776,7 +4783,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -4796,9 +4803,13 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/pdf-parse@1.1.5':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
 
   '@types/picomatch@4.0.3': {}
 
@@ -4821,7 +4832,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
 
   '@types/ssh2@1.15.5':
     dependencies:
@@ -4836,17 +4847,17 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
     optional: true
 
   '@ungap/structured-clone@1.3.3': {}
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vitejs/plugin-react@6.0.3(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.3(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0)
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0)
 
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
@@ -4860,7 +4871,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -4871,13 +4882,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0)
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -7187,7 +7198,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.2
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -7837,6 +7848,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.18.2: {}
+
   undici@6.28.0: {}
 
   undici@7.29.0: {}
@@ -7931,7 +7944,7 @@ snapshots:
 
   vite-plugin-electron@0.28.8: {}
 
-  vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0):
+  vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -7939,16 +7952,16 @@ snapshots:
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 1.21.7
       yaml: 2.9.0
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -7965,11 +7978,11 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0)
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -739,6 +739,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   getPermissions: () => ipcRenderer.invoke('security:getPermissions'),
   resetPermissions: () => ipcRenderer.invoke('security:resetPermissions'),
+  requestExternalFileAccess: (filePath: string) =>
+    ipcRenderer.invoke('security:requestExternalFileAccess', filePath) as Promise<{
+      allowed: boolean
+      reason: 'invalid-path' | 'sensitive-path' | 'already-granted' | 'granted' | 'denied'
+    }>,
 
   onFileChanged: (callback: (event: { event: 'create' | 'update' | 'delete'; path: string }) => void) => {
     const handler = (_: IpcRendererEvent, data: { event: 'create' | 'update' | 'delete'; path: string }) => callback(data)

--- a/src/main/security/secureFile.ts
+++ b/src/main/security/secureFile.ts
@@ -5,7 +5,7 @@
 
 import { logger } from '@shared/utils/Logger'
 import { toAppError, ErrorCode } from '@shared/utils/errorHandler'
-import { ipcMain, dialog, shell } from 'electron'
+import { ipcMain, dialog, shell, BrowserWindow } from 'electron'
 import * as path from 'path'
 import { pathToFileURL } from 'url'
 import { promises as fsPromises } from 'fs'
@@ -82,7 +82,8 @@ type FileAccessKind = 'read' | 'write' | 'manage'
 
 /**
  * Single policy entry point for renderer-originated file access.
- * Agent tools retain their own workspace-only validation before reaching IPC.
+ * Agent read tools may request an external-file grant under strict mode,
+ * or read freely when strict workspace mode is disabled (still blocking sensitive paths).
  */
 function canAccessFile(
   filePath: string,
@@ -831,6 +832,48 @@ export function registerSecureFileHandlers(
     const securityStore = new Store({ name: 'security' })
     securityStore.delete('permissions')
     return true
+  })
+
+  /**
+   * Agent tools may need a one-shot external-file grant under strict workspace mode.
+   * Shows a native confirmation dialog; on allow, persists a session grant so IPC reads succeed.
+   */
+  ipcMain.handle('security:requestExternalFileAccess', async (_event, filePath: string) => {
+    if (!filePath || typeof filePath !== 'string') {
+      return { allowed: false, reason: 'invalid-path' as const }
+    }
+    if (securityManager.isSensitivePath(filePath)) {
+      return { allowed: false, reason: 'sensitive-path' as const }
+    }
+    if (isUserAuthorizedFile(filePath)) {
+      return { allowed: true, reason: 'already-granted' as const }
+    }
+
+    const mainWindow = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0]
+    const { response } = await dialog.showMessageBox(mainWindow, {
+      type: 'warning',
+      buttons: ['允许', '拒绝'],
+      defaultId: 1,
+      cancelId: 1,
+      title: '外部路径访问确认',
+      message: 'Agent 请求读取工作区外的文件',
+      detail: `路径：${filePath}\n\n允许后仅授权该文件的读取（会话内有效）。`,
+    })
+
+    const allowed = response === 0
+    if (allowed) {
+      authorizeUserFile(filePath, 'agent-read')
+      securityManager.logOperation(OperationType.FILE_READ, filePath, true, {
+        reason: 'external-path-granted',
+        source: 'agent-read',
+      })
+    } else {
+      securityManager.logOperation(OperationType.FILE_READ, filePath, false, {
+        reason: 'external-path-denied',
+        source: 'agent-read',
+      })
+    }
+    return { allowed, reason: allowed ? ('granted' as const) : ('denied' as const) }
   })
 }
 

--- a/src/main/security/userFileAccess.ts
+++ b/src/main/security/userFileAccess.ts
@@ -1,6 +1,7 @@
 import * as path from 'path'
 
-export type UserFileGrantSource = 'file-association' | 'file-picker' | 'save-picker' | 'lsp-navigation'
+export type UserFileGrantSource = 'file-association' | 'file-picker' | 'save-picker' | 'lsp-navigation' | 'agent-read'
+
 
 interface UserFileGrant {
   source: UserFileGrantSource

--- a/src/renderer/agent/tools/executors.ts
+++ b/src/renderer/agent/tools/executors.ts
@@ -9,7 +9,7 @@ import { resolveEditFileRequest } from '@/shared/utils/editFile'
 import { resolveReadFileRequest } from '@/shared/utils/readFile'
 import { logger } from '@utils/Logger'
 import type { ToolExecutionResult, ToolExecutionContext } from '@/shared/types'
-import { validatePath, isSensitivePath, platform, getDirname } from '@shared/utils/pathUtils'
+import { validatePath, isSensitivePath, platform, getDirname, toFullPath, isPathInWorkspace } from '@shared/utils/pathUtils'
 import { pathToLspUri } from '@shared/utils/uriUtils'
 import { waitForDiagnostics, isLanguageSupported, getLanguageId, didOpenDocument } from '@/renderer/services/lspService'
 import {
@@ -200,9 +200,55 @@ function formatDirTree(nodes: DirTreeNode[], prefix = ''): string {
     return result
 }
 
-function resolvePath(p: unknown, workspacePath: string | null, allowRead = false): string {
+/**
+ * Resolve a tool path with workspace security policy.
+ * - Writes stay workspace-bound.
+ * - Reads may leave the workspace when strict mode is off, or after an explicit user grant.
+ */
+async function resolvePath(p: unknown, workspacePath: string | null, allowRead = false): Promise<string> {
     if (typeof p !== 'string') throw new Error('Invalid path: not a string')
-    const validation = validatePath(p, workspacePath, { allowSensitive: false, allowOutsideWorkspace: false })
+
+    let validation = validatePath(p, workspacePath, {
+        allowSensitive: false,
+        allowOutsideWorkspace: false,
+    })
+
+    if (!validation.valid && validation.error === 'Path is outside workspace') {
+        if (!allowRead) {
+            throw new Error(`Security: ${validation.error}`)
+        }
+
+        const fullPath = toFullPath(p, workspacePath)
+        const strictWorkspaceMode = useStore.getState().securitySettings?.strictWorkspaceMode !== false
+
+        if (!strictWorkspaceMode) {
+            validation = validatePath(p, workspacePath, {
+                allowSensitive: false,
+                allowOutsideWorkspace: true,
+            })
+        } else {
+            // Already inside workspace after normalization? (shouldn't happen, but keep safe)
+            if (workspacePath && isPathInWorkspace(fullPath, workspacePath)) {
+                validation = validatePath(p, workspacePath, {
+                    allowSensitive: false,
+                    allowOutsideWorkspace: false,
+                })
+            } else {
+                const decision = await api.security.requestExternalFileAccess(fullPath)
+                if (!decision.allowed) {
+                    throw new Error(
+                        `Security: External path access ${decision.reason === 'denied' ? 'denied by user' : 'rejected'} (${fullPath}). ` +
+                        'Open the file in the IDE, or disable Strict workspace mode in Settings → Security.',
+                    )
+                }
+                validation = validatePath(p, workspacePath, {
+                    allowSensitive: false,
+                    allowOutsideWorkspace: true,
+                })
+            }
+        }
+    }
+
     if (!validation.valid) throw new Error(`Security: ${validation.error}`)
     if (!allowRead && isSensitivePath(validation.sanitizedPath!)) {
         throw new Error('Security: Cannot modify sensitive files')
@@ -857,7 +903,7 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
             meta?: Record<string, unknown>
             error?: string
         }> => {
-            const validPath = resolvePath(inputPath, ctx.workspacePath, true)
+            const validPath = await resolvePath(inputPath, ctx.workspacePath, true)
             const extension = getFileExtension(validPath)
 
             if (IMAGE_EXTENSIONS.has(extension)) {
@@ -1036,7 +1082,7 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
             }
         }
 
-        const validPath = resolvePath(pathArg, ctx.workspacePath, true)
+        const validPath = await resolvePath(pathArg, ctx.workspacePath, true)
         const prompt = typeof args.prompt === 'string' ? args.prompt : undefined
         const result = await analyzeImageSource({
             path: validPath,
@@ -1060,7 +1106,7 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
     },
 
     async list_directory(args, ctx) {
-        const path = resolvePath(args.path, ctx.workspacePath, true)
+        const path = await resolvePath(args.path, ctx.workspacePath, true)
         const recursive = args.recursive as boolean | undefined
         const maxDepth = (args.max_depth as number) || 3
 
@@ -1082,7 +1128,7 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
 
     async search_files(args, ctx) {
         const pathArg = args.path as string
-        const resolvedPath = resolvePath(pathArg, ctx.workspacePath, true)
+        const resolvedPath = await resolvePath(pathArg, ctx.workspacePath, true)
         const pattern = args.pattern as string
         // 自动启用 regex 模式（如果包含 | 符号）
         const isRegex = !!args.is_regex || pattern.includes('|')
@@ -1138,7 +1184,7 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
     },
 
     async edit_file(args, ctx) {
-        const path = resolvePath(args.path, ctx.workspacePath)
+        const path = await resolvePath(args.path, ctx.workspacePath)
         // 编辑会把结果整体写回，读取截断等于把文件尾部删掉。
         const originalContent = await api.file.read(path, undefined, { full: true })
         if (originalContent === null) return { success: false, result: '', error: `File not found: ${path}. Use write_file to create new files.` }
@@ -1556,7 +1602,7 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
     async write_file(args, ctx) {
         // write_file 的职责被严格限定为“新建文件 / 整文件重写”。
         // 因此在真正落盘前，先经过统一策略守卫，避免把局部修改误用成整文件覆盖。
-        const path = resolvePath(args.path, ctx.workspacePath)
+        const path = await resolvePath(args.path, ctx.workspacePath)
         const content = args.content as string
         const originalContent = await api.file.read(path, undefined, { full: true }) || ''
         const writeDecision = guardWriteFile({
@@ -1626,7 +1672,7 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
     },
 
     async create_directory(args, ctx) {
-        const path = resolvePath(args.path, ctx.workspacePath)
+        const path = await resolvePath(args.path, ctx.workspacePath)
         const normalizedPath = path.endsWith('/') || path.endsWith('\\')
             ? path.slice(0, -1)
             : path
@@ -1643,7 +1689,7 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
     },
 
     async delete_file_or_folder(args, ctx) {
-        const path = resolvePath(args.path, ctx.workspacePath)
+        const path = await resolvePath(args.path, ctx.workspacePath)
         const success = await api.file.delete(path)
         if (success) {
             notifyComposerChange({ filePath: path, workspacePath: ctx.workspacePath || '', oldContent: null, newContent: null, changeType: 'delete', linesAdded: 0, linesRemoved: 0 })
@@ -1677,7 +1723,7 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
             remoteServerForTrust = remoteLink?.remote || null
             const resolvedCwd = remoteLink
                 ? null
-                : (args.cwd ? resolvePath(args.cwd, ctx.workspacePath, true) : null)
+                : (args.cwd ? await resolvePath(args.cwd, ctx.workspacePath, true) : null)
 
             if (!remoteLink && !isLongRunningProcess) {
                 const directExecutionResult = await runInlineScriptViaTempFile(command, ctx, timeout)
@@ -2225,7 +2271,7 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
     },
 
     async get_lint_errors(args, ctx) {
-        const path = resolvePath(args.path, ctx.workspacePath, true)
+        const path = await resolvePath(args.path, ctx.workspacePath, true)
         const { errors, notInstalled } = await lintService.getLintErrors(path, args.refresh as boolean)
         if (notInstalled) {
             return { success: true, result: notInstalled }
@@ -2245,7 +2291,7 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
     },
 
     async find_references(args, ctx) {
-        const path = resolvePath(args.path, ctx.workspacePath, true)
+        const path = await resolvePath(args.path, ctx.workspacePath, true)
         const locations = await api.lsp.references({
             uri: pathToLspUri(path), line: (args.line as number) - 1, character: (args.column as number) - 1, workspacePath: ctx.workspacePath
         })
@@ -2267,7 +2313,7 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
     },
 
     async go_to_definition(args, ctx) {
-        const path = resolvePath(args.path, ctx.workspacePath, true)
+        const path = await resolvePath(args.path, ctx.workspacePath, true)
         const locations = await api.lsp.definition({
             uri: pathToLspUri(path), line: (args.line as number) - 1, character: (args.column as number) - 1, workspacePath: ctx.workspacePath
         })
@@ -2289,7 +2335,7 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
     },
 
     async get_hover_info(args, ctx) {
-        const path = resolvePath(args.path, ctx.workspacePath, true)
+        const path = await resolvePath(args.path, ctx.workspacePath, true)
         const hover = await api.lsp.hover({
             uri: pathToLspUri(path), line: (args.line as number) - 1, character: (args.column as number) - 1, workspacePath: ctx.workspacePath
         })
@@ -2299,7 +2345,7 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
     },
 
     async get_document_symbols(args, ctx) {
-        const path = resolvePath(args.path, ctx.workspacePath, true)
+        const path = await resolvePath(args.path, ctx.workspacePath, true)
         const symbols = await api.lsp.documentSymbol({ uri: pathToLspUri(path), workspacePath: ctx.workspacePath })
         if (!symbols?.length) return { success: true, result: 'No symbols found' }
 

--- a/src/renderer/services/electronAPI.ts
+++ b/src/renderer/services/electronAPI.ts
@@ -217,6 +217,7 @@ function createGroupedAPI() {
     security: {
       getPermissions: () => raw.getPermissions(),
       resetPermissions: () => raw.resetPermissions(),
+      requestExternalFileAccess: (filePath: string) => raw.requestExternalFileAccess(filePath),
     },
 
     // 索引

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -552,6 +552,10 @@ export interface ElectronAPI {
   // Security
   getPermissions: () => Promise<Record<string, string>>
   resetPermissions: () => Promise<boolean>
+  requestExternalFileAccess: (filePath: string) => Promise<{
+    allowed: boolean
+    reason: 'invalid-path' | 'sensitive-path' | 'already-granted' | 'granted' | 'denied'
+  }>
 
   // Index
   indexInitialize: (workspacePath: string) => Promise<{ success: boolean; error?: string }>

--- a/src/shared/utils/readFile.ts
+++ b/src/shared/utils/readFile.ts
@@ -85,7 +85,21 @@ export function resolveReadFileRequest(data: Record<string, unknown>): ReadFileR
   }
 
   if (typeof start_line === 'number' && typeof end_line === 'number' && start_line > end_line) {
-    return { ok: false, normalized, error: 'start_line must be <= end_line' }
+    // Models frequently invert the range; auto-correct for reads instead of failing the tool call.
+    return {
+      ok: true,
+      mode: 'single',
+      normalized: {
+        ...normalized,
+        start_line: end_line,
+        end_line: start_line,
+      },
+      args: {
+        path: parsedPath,
+        start_line: end_line,
+        end_line: start_line,
+      },
+    }
   }
 
   return {

--- a/tests/main/security/userFileAccess.test.ts
+++ b/tests/main/security/userFileAccess.test.ts
@@ -19,10 +19,10 @@ describe('user file session grants', () => {
     expect(isUserAuthorizedFile(path.dirname(target))).toBe(false)
   })
 
-  it('can revoke all grants at the session boundary', () => {
-    const target = path.resolve('outside', 'opened.py')
-    authorizeUserFile(target, 'file-association')
-    clearUserFileGrants()
-    expect(isUserAuthorizedFile(target)).toBe(false)
+  it('authorizes agent-read grants for exact files', () => {
+    const target = path.resolve('outside', 'agent-target.ts')
+    authorizeUserFile(target, 'agent-read')
+    expect(isUserAuthorizedFile(target)).toBe(true)
+    expect(isUserAuthorizedFile(path.resolve('outside', 'other.ts'))).toBe(false)
   })
 })

--- a/tests/unit/shared/utils/readFile.test.ts
+++ b/tests/unit/shared/utils/readFile.test.ts
@@ -39,16 +39,17 @@ describe('readFile utils', () => {
     }
   })
 
-  it('rejects inverted line ranges', () => {
+  it('auto-swaps inverted line ranges instead of failing', () => {
     const result = resolveReadFileRequest({
       path: 'src/main.ts',
       start_line: 9,
       end_line: 5,
     })
 
-    expect(result.ok).toBe(false)
-    if (!result.ok) {
-      expect(result.error).toContain('start_line must be <=')
+    expect(result.ok).toBe(true)
+    if (result.ok && result.mode === 'single') {
+      expect(result.args.start_line).toBe(5)
+      expect(result.args.end_line).toBe(9)
     }
   })
 })


### PR DESCRIPTION
and fix #158

- Added `requestExternalFileAccess` method to the Electron API for requesting access to files outside the workspace.
- Enhanced security handling in `secureFile.ts` to manage external file access requests with user confirmation.
- Updated `resolvePath` function in executors to support external file access under strict workspace mode.
- Modified user file access logic to include 'agent-read' as a valid grant source.
- Improved tests to cover new external file access functionality and ensure proper authorization handling.
#158 