### PR TITLE
feat: add GitHub download mirror support for update service and fix #153

### DIFF
--- a/src/main/services/updater/UpdateService.ts
+++ b/src/main/services/updater/UpdateService.ts
@@ -17,6 +17,16 @@ import { ErrorCode, toAppError } from '@shared/utils/errorHandler'
 import * as fs from 'fs'
 import * as path from 'path'
 import { fetchLatestRelease } from '../githubApiService'
+import {
+  GITHUB_DOWNLOAD_MIRRORS,
+  applyGithubDownloadMirror,
+  buildMirroredGithubLatestFeedUrl,
+  resolveUpdateDownloadSource,
+  type UpdateDownloadSource,
+} from '@shared/utils/githubDownloadMirror'
+
+const UPDATE_OWNER = 'ad-naan'
+const UPDATE_REPO = 'adnify'
 
 export interface UpdateStatus {
   status: 'idle' | 'checking' | 'available' | 'not-available' | 'downloading' | 'downloaded' | 'error'
@@ -28,6 +38,8 @@ export interface UpdateStatus {
   error?: string
   requiresManualDownload: boolean
   isPortable: boolean
+  /** Whether downloads are routed through a GitHub mirror. */
+  usingDownloadMirror?: boolean
 }
 
 class UpdateService {
@@ -35,10 +47,13 @@ class UpdateService {
     status: 'idle',
     requiresManualDownload: false,
     isPortable: false,
+    usingDownloadMirror: false,
   }
 
   private mainWindow: BrowserWindow | null = null
   private updateCheckInterval: NodeJS.Timeout | null = null
+  private downloadSource: UpdateDownloadSource = 'github'
+  private activeMirrorIndex = 0
 
   initialize(mainWindow: BrowserWindow): void {
     this.mainWindow = mainWindow
@@ -48,8 +63,14 @@ class UpdateService {
     // Backward-compatible alias for existing consumers.
     this.status.isPortable = requiresManualDownload
 
+    this.downloadSource = resolveUpdateDownloadSource({
+      locale: app.getLocale(),
+      envForce: process.env.ADNIFY_UPDATE_MIRROR,
+    })
+    this.status.usingDownloadMirror = this.downloadSource === 'mirror'
+
     logger.system.info(
-      `[Updater] Initialized, requiresManualDownload: ${requiresManualDownload}, platform: ${process.platform}`
+      `[Updater] Initialized, requiresManualDownload: ${requiresManualDownload}, platform: ${process.platform}, downloadSource: ${this.downloadSource}`
     )
 
     if (requiresManualDownload) {
@@ -94,11 +115,7 @@ class UpdateService {
 
     const channel = this.getUpdateChannel()
     autoUpdater.channel = channel
-    autoUpdater.setFeedURL({
-      provider: 'github',
-      owner: 'ad-naan',
-      repo: 'adnify',
-    })
+    this.applyUpdateFeed(this.downloadSource, this.activeMirrorIndex)
 
     logger.system.info(`[Updater] Using update channel: ${channel}`)
 
@@ -304,19 +321,48 @@ class UpdateService {
 
   async downloadUpdate(): Promise<void> {
     if (this.status.requiresManualDownload) {
-      throw new Error('当前安装方式不支持自动下载，请前往发布页手动下载。')
+      throw new Error('当前安装方式不支持应用内自动更新。请点击「前往下载页」获取对应安装包（已尽量使用加速链接）。')
     }
 
-    if (this.status.status !== 'available') {
+    if (this.status.status !== 'available' && !(this.status.status === 'error' && this.status.version)) {
       throw new Error('No update available')
     }
 
-    await autoUpdater.downloadUpdate()
+    this.updateStatus({ status: 'downloading', progress: 0, error: undefined })
+
+    try {
+      await autoUpdater.downloadUpdate()
+      return
+    } catch (primaryError) {
+      logger.system.warn('[Updater] Primary download failed, trying mirror fallback:', primaryError)
+
+      if (this.downloadSource === 'github') {
+        this.downloadSource = 'mirror'
+        this.activeMirrorIndex = 0
+        this.applyUpdateFeed('mirror', 0)
+        this.updateStatus({ usingDownloadMirror: true })
+        await autoUpdater.checkForUpdates()
+        await autoUpdater.downloadUpdate()
+        return
+      }
+
+      // Already on mirror: rotate to the next mirror prefix once.
+      const nextIndex = this.activeMirrorIndex + 1
+      if (nextIndex < GITHUB_DOWNLOAD_MIRRORS.length) {
+        this.activeMirrorIndex = nextIndex
+        this.applyUpdateFeed('mirror', nextIndex)
+        await autoUpdater.checkForUpdates()
+        await autoUpdater.downloadUpdate()
+        return
+      }
+
+      throw primaryError
+    }
   }
 
   quitAndInstall(): void {
     if (this.status.requiresManualDownload) {
-      throw new Error('当前安装方式不支持自动安装。')
+      throw new Error('当前安装方式不支持应用内自动安装。请使用下载页中的安装包完成升级。')
     }
 
     if (this.status.status !== 'downloaded') {
@@ -398,13 +444,40 @@ class UpdateService {
     }
 
     const regexes = patterns[key] || []
+    let directUrl = `https://github.com/${UPDATE_OWNER}/${UPDATE_REPO}/releases/latest`
     for (const asset of assets) {
       if (regexes.some(regex => regex.test(asset.name))) {
-        return asset.browser_download_url
+        directUrl = asset.browser_download_url
+        break
       }
     }
 
-    return 'https://github.com/ad-naan/adnify/releases/latest'
+    if (this.downloadSource === 'mirror') {
+      return applyGithubDownloadMirror(directUrl, GITHUB_DOWNLOAD_MIRRORS[this.activeMirrorIndex] || GITHUB_DOWNLOAD_MIRRORS[0])
+    }
+    return directUrl
+  }
+
+  private applyUpdateFeed(source: UpdateDownloadSource, mirrorIndex = 0): void {
+    if (source === 'mirror') {
+      const mirror = GITHUB_DOWNLOAD_MIRRORS[mirrorIndex] || GITHUB_DOWNLOAD_MIRRORS[0]
+      const feedUrl = buildMirroredGithubLatestFeedUrl(UPDATE_OWNER, UPDATE_REPO, mirror)
+      autoUpdater.setFeedURL({
+        provider: 'generic',
+        url: feedUrl,
+      })
+      logger.system.info(`[Updater] Feed set to mirrored generic URL: ${feedUrl}`)
+      this.updateStatus({ usingDownloadMirror: true })
+      return
+    }
+
+    autoUpdater.setFeedURL({
+      provider: 'github',
+      owner: UPDATE_OWNER,
+      repo: UPDATE_REPO,
+    })
+    logger.system.info('[Updater] Feed set to GitHub provider')
+    this.updateStatus({ usingDownloadMirror: false })
   }
 
   private getUpdateChannel(): string {

--- a/src/renderer/components/layout/UpdateIndicator.tsx
+++ b/src/renderer/components/layout/UpdateIndicator.tsx
@@ -70,7 +70,13 @@ export default function UpdateIndicator() {
     openPage: language === 'zh' ? '前往下载页' : 'Open Download Page',
     checkNow: language === 'zh' ? '检查更新' : 'Check for Updates',
     manualHint:
-      language === 'zh' ? '当前安装方式不支持应用内更新，请前往发布页下载最新版本。' : 'This install type cannot update in-app. Please download the latest release manually.',
+      language === 'zh'
+        ? '当前是便携版 / 非标准安装，无法在应用内自动安装。请下载对应安装包后手动覆盖或重新安装。下载链接已尽量走加速镜像。'
+        : 'This is a portable or non-standard install, so in-app auto-install is unavailable. Download the matching package and replace/reinstall manually. Download links use an acceleration mirror when available.',
+    mirrorHint:
+      language === 'zh'
+        ? '已启用 GitHub 下载加速，可显著改善国内网络下的更新速度。'
+        : 'GitHub download acceleration is enabled to improve update speed on restricted networks.',
     current: language === 'zh' ? '当前版本' : 'Current',
   }
 
@@ -199,8 +205,14 @@ export default function UpdateIndicator() {
               )}
 
               {hasUpdate && status?.requiresManualDownload && (
-                <div className="mb-6 px-4 py-3 rounded-2xl bg-amber-500/10 border border-amber-500/20 text-[11px] text-amber-200/80 leading-relaxed text-center">
+                <div className="mb-4 px-4 py-3 rounded-2xl bg-amber-500/10 border border-amber-500/20 text-[11px] text-amber-200/80 leading-relaxed text-center">
                   {t.manualHint}
+                </div>
+              )}
+
+              {status?.usingDownloadMirror && (
+                <div className="mb-4 px-4 py-2.5 rounded-2xl bg-sky-500/10 border border-sky-500/20 text-[11px] text-sky-200/80 leading-relaxed text-center">
+                  {t.mirrorHint}
                 </div>
               )}
 

--- a/src/renderer/services/updaterService.ts
+++ b/src/renderer/services/updaterService.ts
@@ -14,6 +14,7 @@ export interface UpdateStatus {
   error?: string
   requiresManualDownload: boolean
   isPortable: boolean
+  usingDownloadMirror?: boolean
 }
 
 class UpdaterService {

--- a/src/shared/utils/githubDownloadMirror.ts
+++ b/src/shared/utils/githubDownloadMirror.ts
@@ -1,0 +1,68 @@
+/**
+ * GitHub release download mirrors (mainly for mainland China networks).
+ * Prefix form: https://<mirror>/<original-https-url>
+ */
+
+export const GITHUB_DOWNLOAD_MIRRORS = [
+  'https://ghfast.top/',
+  'https://gh-proxy.com/',
+  'https://mirror.ghproxy.com/',
+] as const
+
+const GITHUB_HOSTS = new Set([
+  'github.com',
+  'objects.githubusercontent.com',
+  'release-assets.githubusercontent.com',
+])
+
+export function isGithubDownloadUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return GITHUB_HOSTS.has(parsed.hostname) || parsed.hostname.endsWith('.githubusercontent.com')
+  } catch {
+    return false
+  }
+}
+
+export function normalizeMirrorPrefix(mirror: string): string {
+  const trimmed = mirror.trim()
+  if (!trimmed) return ''
+  return trimmed.endsWith('/') ? trimmed : `${trimmed}/`
+}
+
+/** Build a proxied URL; no-op for non-GitHub URLs or empty mirrors. */
+export function applyGithubDownloadMirror(url: string, mirrorPrefix: string): string {
+  if (!url || !mirrorPrefix || !isGithubDownloadUrl(url)) return url
+  if (url.startsWith(mirrorPrefix)) return url
+  return `${normalizeMirrorPrefix(mirrorPrefix)}${url}`
+}
+
+/**
+ * Generic electron-updater feed that points at GitHub "latest/download"
+ * through a mirror, so channel yml + assets both go via the proxy.
+ */
+export function buildMirroredGithubLatestFeedUrl(
+  owner: string,
+  repo: string,
+  mirrorPrefix: string,
+): string {
+  const direct = `https://github.com/${owner}/${repo}/releases/latest/download`
+  return applyGithubDownloadMirror(direct, mirrorPrefix)
+}
+
+export type UpdateDownloadSource = 'github' | 'mirror'
+
+export function resolveUpdateDownloadSource(options: {
+  locale?: string
+  envForce?: string | undefined
+}): UpdateDownloadSource {
+  const force = (options.envForce || '').trim().toLowerCase()
+  if (force === '0' || force === 'false' || force === 'github' || force === 'direct') {
+    return 'github'
+  }
+  if (force === '1' || force === 'true' || force === 'mirror') {
+    return 'mirror'
+  }
+  const locale = (options.locale || '').toLowerCase()
+  return locale.startsWith('zh') ? 'mirror' : 'github'
+}

--- a/tests/unit/shared/utils/githubDownloadMirror.test.ts
+++ b/tests/unit/shared/utils/githubDownloadMirror.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyGithubDownloadMirror,
+  buildMirroredGithubLatestFeedUrl,
+  isGithubDownloadUrl,
+  resolveUpdateDownloadSource,
+} from '@/shared/utils/githubDownloadMirror'
+
+describe('githubDownloadMirror', () => {
+  it('detects github download hosts', () => {
+    expect(isGithubDownloadUrl('https://github.com/ad-naan/adnify/releases/download/v1.0.0/a.exe')).toBe(true)
+    expect(isGithubDownloadUrl('https://example.com/a.exe')).toBe(false)
+  })
+
+  it('prefixes mirror once', () => {
+    const url = 'https://github.com/ad-naan/adnify/releases/download/v1.0.0/a.exe'
+    const mirrored = applyGithubDownloadMirror(url, 'https://ghfast.top/')
+    expect(mirrored).toBe(`https://ghfast.top/${url}`)
+    expect(applyGithubDownloadMirror(mirrored, 'https://ghfast.top/')).toBe(mirrored)
+  })
+
+  it('builds mirrored latest/download feed', () => {
+    expect(buildMirroredGithubLatestFeedUrl('ad-naan', 'adnify', 'https://ghfast.top/')).toBe(
+      'https://ghfast.top/https://github.com/ad-naan/adnify/releases/latest/download',
+    )
+  })
+
+  it('resolves source from locale and env override', () => {
+    expect(resolveUpdateDownloadSource({ locale: 'zh-CN' })).toBe('mirror')
+    expect(resolveUpdateDownloadSource({ locale: 'en-US' })).toBe('github')
+    expect(resolveUpdateDownloadSource({ locale: 'zh-CN', envForce: 'github' })).toBe('github')
+    expect(resolveUpdateDownloadSource({ locale: 'en-US', envForce: 'mirror' })).toBe('mirror')
+  })
+})


### PR DESCRIPTION
- Introduced functionality to use download mirrors for GitHub releases, improving update speed in restricted networks.
- Enhanced UpdateService to resolve download source based on locale and environment variables.
- Updated UpdateIndicator to display mirror usage status and provide relevant hints to users.
- Added utility functions for managing GitHub download mirrors and created unit tests to ensure reliability.
- Modified error messages for manual download and installation to provide clearer instructions fix #153.

