### PR TITLE
feat: enhance remote file upload functionality

### DIFF
--- a/src/main/ipc/remoteShell.ts
+++ b/src/main/ipc/remoteShell.ts
@@ -4,10 +4,11 @@ import path from 'path'
 import { pipeline } from 'stream/promises'
 import type { Client as Ssh2Client, ConnectConfig, FileEntry, SFTPWrapper, Stats } from 'ssh2'
 import {
-  REMOTE_DIR_DOWNLOAD_MAX_DEPTH,
-  REMOTE_DIR_DOWNLOAD_MAX_ENTRIES,
+  REMOTE_DIR_TRANSFER_MAX_DEPTH,
+  REMOTE_DIR_TRANSFER_MAX_ENTRIES,
   assertSafeRemoteName,
   buildDirectoryDownloadTarget,
+  buildDirectoryUploadRemoteTarget,
   isSftpSymbolicLinkMode,
   safeJoinUnderDownloadRoot,
 } from '@shared/utils/remoteDownloadPath'
@@ -35,7 +36,13 @@ let CachedClient: typeof Ssh2Client | null = null
 interface RemoteUploadResult {
   canceled: boolean
   uploaded: string[]
+  uploadedCount?: number
+  skippedSymlinks?: number
+  isDirectory?: boolean
 }
+
+export type RemoteUploadMode = 'files' | 'directory'
+
 
 interface RemoteDownloadResult {
   canceled: boolean
@@ -297,6 +304,60 @@ async function uploadLocalFile(sftp: SFTPWrapper, localPath: string, remotePath:
   await pipeline(fs.createReadStream(localPath), sftp.createWriteStream(remotePath))
 }
 
+interface DirectoryTransferStats {
+  uploadedCount: number
+  skippedSymlinks: number
+  entryCount: number
+}
+
+async function uploadLocalDirectory(
+  sftp: SFTPWrapper,
+  localDir: string,
+  remoteDir: string,
+  stats: DirectoryTransferStats = { uploadedCount: 0, skippedSymlinks: 0, entryCount: 0 },
+  depth = 0,
+): Promise<DirectoryTransferStats> {
+  if (depth > REMOTE_DIR_TRANSFER_MAX_DEPTH) {
+    throw new Error(`Local directory exceeds max depth (${REMOTE_DIR_TRANSFER_MAX_DEPTH})`)
+  }
+
+  await mkdirRecursive(sftp, remoteDir)
+  const entries = await fs.promises.readdir(localDir, { withFileTypes: true })
+
+  for (const entry of entries) {
+    if (entry.name === '.' || entry.name === '..') continue
+
+    stats.entryCount += 1
+    if (stats.entryCount > REMOTE_DIR_TRANSFER_MAX_ENTRIES) {
+      throw new Error(`Local directory exceeds max entry limit (${REMOTE_DIR_TRANSFER_MAX_ENTRIES})`)
+    }
+
+    const name = assertSafeRemoteName(entry.name)
+    const localChild = path.join(localDir, entry.name)
+    const remoteChild = joinRemotePath(remoteDir, name)
+
+    if (entry.isSymbolicLink()) {
+      stats.skippedSymlinks += 1
+      continue
+    }
+
+    if (entry.isDirectory()) {
+      await uploadLocalDirectory(sftp, localChild, remoteChild, stats, depth + 1)
+      continue
+    }
+
+    if (!entry.isFile()) {
+      stats.skippedSymlinks += 1
+      continue
+    }
+
+    await uploadLocalFile(sftp, localChild, remoteChild)
+    stats.uploadedCount += 1
+  }
+
+  return stats
+}
+
 async function downloadRemoteFile(sftp: SFTPWrapper, remotePath: string, localPath: string): Promise<void> {
   await fs.promises.mkdir(path.dirname(localPath), { recursive: true })
   await pipeline(sftp.createReadStream(remotePath), fs.createWriteStream(localPath))
@@ -315,8 +376,8 @@ async function downloadRemoteDirectory(
   stats: DirectoryDownloadStats = { downloadedCount: 0, skippedSymlinks: 0, entryCount: 0 },
   depth = 0,
 ): Promise<DirectoryDownloadStats> {
-  if (depth > REMOTE_DIR_DOWNLOAD_MAX_DEPTH) {
-    throw new Error(`Remote directory exceeds max depth (${REMOTE_DIR_DOWNLOAD_MAX_DEPTH})`)
+  if (depth > REMOTE_DIR_TRANSFER_MAX_DEPTH) {
+    throw new Error(`Remote directory exceeds max depth (${REMOTE_DIR_TRANSFER_MAX_DEPTH})`)
   }
 
   await fs.promises.mkdir(localDir, { recursive: true })
@@ -326,8 +387,8 @@ async function downloadRemoteDirectory(
     if (entry.filename === '.' || entry.filename === '..') continue
 
     stats.entryCount += 1
-    if (stats.entryCount > REMOTE_DIR_DOWNLOAD_MAX_ENTRIES) {
-      throw new Error(`Remote directory exceeds max entry limit (${REMOTE_DIR_DOWNLOAD_MAX_ENTRIES})`)
+    if (stats.entryCount > REMOTE_DIR_TRANSFER_MAX_ENTRIES) {
+      throw new Error(`Remote directory exceeds max entry limit (${REMOTE_DIR_TRANSFER_MAX_ENTRIES})`)
     }
 
     const name = assertSafeRemoteName(entry.filename)
@@ -427,30 +488,72 @@ export function registerRemoteShellHandlers(): void {
     }
   })
 
-  ipcMain.handle('remoteShell:upload', async (event, server: RemoteServerConfig, remoteDirectory: string): Promise<RemoteUploadResult> => {
-    const window = BrowserWindow.fromWebContents(event.sender) ?? undefined
-    const selection = await dialog.showOpenDialog(window as BrowserWindow, {
-      title: 'Upload files to remote server',
-      properties: ['openFile', 'multiSelections'],
-    })
+  ipcMain.handle(
+    'remoteShell:upload',
+    async (
+      event,
+      server: RemoteServerConfig,
+      remoteDirectory: string,
+      mode: RemoteUploadMode = 'files',
+    ): Promise<RemoteUploadResult> => {
+      const window = BrowserWindow.fromWebContents(event.sender) ?? undefined
+      const uploadMode: RemoteUploadMode = mode === 'directory' ? 'directory' : 'files'
+      const selection = await dialog.showOpenDialog(window as BrowserWindow, {
+        title: uploadMode === 'directory' ? 'Upload folder to remote server' : 'Upload files to remote server',
+        properties: uploadMode === 'directory'
+          ? ['openDirectory']
+          : ['openFile', 'multiSelections'],
+      })
 
-    if (selection.canceled || selection.filePaths.length === 0) {
-      return { canceled: true, uploaded: [] }
-    }
-
-    const targetDirectory = normalizeRemotePath(remoteDirectory || server.remotePath || '.')
-    const uploaded = await withSftp(server, async (sftp) => {
-      const completed: string[] = []
-      for (const localPath of selection.filePaths) {
-        const remotePath = joinRemotePath(targetDirectory, path.basename(localPath))
-        await uploadLocalFile(sftp, localPath, remotePath)
-        completed.push(remotePath)
+      if (selection.canceled || selection.filePaths.length === 0) {
+        return { canceled: true, uploaded: [], isDirectory: uploadMode === 'directory' }
       }
-      return completed
-    })
 
-    return { canceled: false, uploaded }
-  })
+      const targetDirectory = normalizeRemotePath(remoteDirectory || server.remotePath || '.')
+
+      if (uploadMode === 'directory') {
+        const localDir = selection.filePaths[0]
+        const localStat = await fs.promises.lstat(localDir)
+        if (!localStat.isDirectory() || localStat.isSymbolicLink()) {
+          throw new Error('Selected path is not a regular directory')
+        }
+
+        const remotePath = buildDirectoryUploadRemoteTarget(targetDirectory, localDir)
+        const stats = await withSftp(server, async (sftp) => (
+          uploadLocalDirectory(sftp, localDir, remotePath)
+        ))
+
+        return {
+          canceled: false,
+          uploaded: [remotePath],
+          uploadedCount: stats.uploadedCount,
+          skippedSymlinks: stats.skippedSymlinks,
+          isDirectory: true,
+        }
+      }
+
+      const uploaded = await withSftp(server, async (sftp) => {
+        const completed: string[] = []
+        for (const localPath of selection.filePaths) {
+          const localStat = await fs.promises.lstat(localPath)
+          if (!localStat.isFile() || localStat.isSymbolicLink()) {
+            throw new Error(`Skipping non-file selection is not supported in file upload mode: ${localPath}`)
+          }
+          const remotePath = joinRemotePath(targetDirectory, path.basename(localPath))
+          await uploadLocalFile(sftp, localPath, remotePath)
+          completed.push(remotePath)
+        }
+        return completed
+      })
+
+      return {
+        canceled: false,
+        uploaded,
+        uploadedCount: uploaded.length,
+        isDirectory: false,
+      }
+    },
+  )
 
   ipcMain.handle('remoteShell:download', async (event, server: RemoteServerConfig, remotePath: string): Promise<RemoteDownloadResult> => {
     const normalizedRemotePath = assertSafeExplicitRemotePath(remotePath, 'download')

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -341,7 +341,13 @@ export interface ElectronAPI {
   remoteShellRename: (server: RemoteShellServer, oldPath: string, newPath: string) => Promise<boolean>
   remoteShellDelete: (server: RemoteShellServer, remotePath: string) => Promise<boolean>
   remoteShellTestConnection: (server: RemoteShellServer) => Promise<{ success: boolean; error?: string }>
-  remoteShellUpload: (server: RemoteShellServer, remoteDirectory: string) => Promise<{ canceled: boolean; uploaded: string[] }>
+  remoteShellUpload: (server: RemoteShellServer, remoteDirectory: string, mode?: 'files' | 'directory') => Promise<{
+    canceled: boolean
+    uploaded: string[]
+    uploadedCount?: number
+    skippedSymlinks?: number
+    isDirectory?: boolean
+  }>
   remoteShellDownload: (server: RemoteShellServer, remotePath: string) => Promise<{
     canceled: boolean
     localPath?: string
@@ -733,7 +739,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   remoteShellRename: (server: RemoteShellServer, oldPath: string, newPath: string) => ipcRenderer.invoke('remoteShell:rename', server, oldPath, newPath),
   remoteShellDelete: (server: RemoteShellServer, remotePath: string) => ipcRenderer.invoke('remoteShell:delete', server, remotePath),
   remoteShellTestConnection: (server: RemoteShellServer) => ipcRenderer.invoke('remoteShell:testConnection', server),
-  remoteShellUpload: (server: RemoteShellServer, remoteDirectory: string) => ipcRenderer.invoke('remoteShell:upload', server, remoteDirectory),
+  remoteShellUpload: (server: RemoteShellServer, remoteDirectory: string, mode?: 'files' | 'directory') => ipcRenderer.invoke('remoteShell:upload', server, remoteDirectory, mode),
   remoteShellDownload: (server: RemoteShellServer, remotePath: string) => ipcRenderer.invoke('remoteShell:download', server, remotePath),
   remoteHostTrustGetStatus: (server: RemoteShellServer) => ipcRenderer.invoke('remoteHostTrust:getStatus', server),
   remoteHostTrustGetLastDecision: (server: RemoteShellServer) => ipcRenderer.invoke('remoteHostTrust:getLastDecision', server),

--- a/src/renderer/agent/tools/executors.ts
+++ b/src/renderer/agent/tools/executors.ts
@@ -2195,21 +2195,30 @@ const rawToolExecutors: Record<string, (args: Record<string, unknown>, ctx: Tool
         const trustMetaBase = await buildRemoteTrustMeta(routeResolution.remoteLink!.remote)
 
         try {
-            const uploadResult = await api.remoteShell.upload(routeResolution.remoteLink!.remote, remotePath)
+            const mode = args.mode === 'directory' ? 'directory' : 'files'
+            const uploadResult = await api.remoteShell.upload(routeResolution.remoteLink!.remote, remotePath, mode)
             const trustMeta = await buildRemoteTrustMeta(routeResolution.remoteLink!.remote)
-            return {
-                success: true,
-                result: uploadResult.canceled
-                    ? 'Remote upload canceled by user'
+            const count = uploadResult.uploadedCount ?? uploadResult.uploaded.length
+            const successMessage = uploadResult.canceled
+                ? 'Remote upload canceled by user'
+                : uploadResult.isDirectory
+                    ? `Remote directory uploaded to ${uploadResult.uploaded[0] || remotePath} (${count} file(s)${uploadResult.skippedSymlinks ? `, ${uploadResult.skippedSymlinks} symlink(s) skipped` : ''})`
                     : uploadResult.uploaded.length > 0
                         ? uploadResult.uploaded.join('\n')
-                        : 'No files were uploaded',
+                        : 'No files were uploaded'
+            return {
+                success: true,
+                result: successMessage,
                 meta: {
                     ...routeResolution.routeMeta,
                     ...trustMeta,
                     path: remotePath,
                     canceled: uploadResult.canceled,
                     uploaded: uploadResult.uploaded,
+                    uploadedCount: count,
+                    isDirectory: uploadResult.isDirectory,
+                    skippedSymlinks: uploadResult.skippedSymlinks,
+                    mode,
                 },
             }
         } catch (error) {

--- a/src/renderer/services/electronAPI.ts
+++ b/src/renderer/services/electronAPI.ts
@@ -7,6 +7,7 @@ import type {
   ElectronAPI,
   RemoteShellEntry,
   RemoteShellServer,
+  RemoteShellUploadMode,
   RemoteShellUploadResult,
   RemoteShellDownloadResult,
   RemoteHostTrustDecision,
@@ -20,7 +21,7 @@ type ElectronAPIWithRemoteShell = ElectronAPI & {
   remoteShellRename: (server: RemoteShellServer, oldPath: string, newPath: string) => Promise<boolean>
   remoteShellDelete: (server: RemoteShellServer, remotePath: string) => Promise<boolean>
   remoteShellTestConnection: (server: RemoteShellServer) => Promise<{ success: boolean; error?: string }>
-  remoteShellUpload: (server: RemoteShellServer, remoteDirectory: string) => Promise<RemoteShellUploadResult>
+  remoteShellUpload: (server: RemoteShellServer, remoteDirectory: string, mode?: RemoteShellUploadMode) => Promise<RemoteShellUploadResult>
   remoteShellDownload: (server: RemoteShellServer, remotePath: string) => Promise<RemoteShellDownloadResult>
   remoteHostTrustGetStatus: (server: RemoteShellServer) => Promise<{ known: boolean; fingerprintSha256?: string }>
   remoteHostTrustGetLastDecision: (server: RemoteShellServer) => Promise<RemoteHostTrustDecision | null>
@@ -191,7 +192,8 @@ function createGroupedAPI() {
       rename: (server: RemoteShellServer, oldPath: string, newPath: string) => raw.remoteShellRename(server, oldPath, newPath),
       delete: (server: RemoteShellServer, remotePath: string) => raw.remoteShellDelete(server, remotePath),
       testConnection: (server: RemoteShellServer) => raw.remoteShellTestConnection(server),
-      upload: (server: RemoteShellServer, remoteDirectory: string) => raw.remoteShellUpload(server, remoteDirectory),
+      upload: (server: RemoteShellServer, remoteDirectory: string, mode?: RemoteShellUploadMode) =>
+        raw.remoteShellUpload(server, remoteDirectory, mode),
       download: (server: RemoteShellServer, remotePath: string) => raw.remoteShellDownload(server, remotePath),
     },
 

--- a/src/renderer/shell/components/RemoteFileBrowser.tsx
+++ b/src/renderer/shell/components/RemoteFileBrowser.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { ChevronRight, Download, FileText, Folder, FolderPlus, Pencil, RefreshCw, Save, SquareArrowOutUpRight, Trash2, Upload, Wifi, X } from 'lucide-react'
+import { ChevronRight, Download, FileText, Folder, FolderPlus, FolderUp, Pencil, RefreshCw, Save, SquareArrowOutUpRight, Trash2, Upload, Wifi, X } from 'lucide-react'
 import { Button, Input, Modal } from '@/renderer/components/ui'
 import { globalConfirm } from '@/renderer/components/common/ConfirmDialog'
 import { toast } from '@/renderer/components/common/InlineToast'
@@ -71,6 +71,7 @@ export function RemoteFileBrowser({ server, language, onClose }: RemoteFileBrows
   const [selectedFileContent, setSelectedFileContent] = useState<string>('')
   const [saving, setSaving] = useState(false)
   const [testing, setTesting] = useState(false)
+  const [uploading, setUploading] = useState(false)
   const [downloading, setDownloading] = useState(false)
   const [dirty, setDirty] = useState(false)
   const [nameDialog, setNameDialog] = useState<NameDialogState | null>(null)
@@ -236,26 +237,36 @@ export function RemoteFileBrowser({ server, language, onClose }: RemoteFileBrows
     }
   }, [language, server])
 
-  const handleUpload = useCallback(async () => {
+  const handleUpload = useCallback(async (mode: 'files' | 'directory' = 'files') => {
+    if (uploading || downloading) return
+    setUploading(true)
     try {
-      const result = await api.remoteShell.upload(server, currentPath)
+      const result = await api.remoteShell.upload(server, currentPath, mode)
       if (result.canceled) return
-      if (result.uploaded.length > 0) {
+      const count = result.uploadedCount ?? result.uploaded.length
+      if (count > 0 || result.uploaded.length > 0) {
+        const detail = result.isDirectory
+          ? (language === 'zh'
+            ? `已上传 ${count} 个文件到 ${result.uploaded[0] || currentPath}${result.skippedSymlinks ? `（跳过 ${result.skippedSymlinks} 个符号链接）` : ''}`
+            : `Uploaded ${count} file(s) to ${result.uploaded[0] || currentPath}${result.skippedSymlinks ? ` (${result.skippedSymlinks} symlink(s) skipped)` : ''}`)
+          : (language === 'zh'
+            ? `已上传 ${count} 个文件到当前目录`
+            : `${count} file(s) uploaded to the current directory`)
         toast.success(
-          language === 'zh' ? '文件上传成功' : 'Upload completed',
-          language === 'zh'
-            ? `已上传 ${result.uploaded.length} 个文件到当前目录`
-            : `${result.uploaded.length} file(s) uploaded to the current directory`,
+          language === 'zh' ? '上传成功' : 'Upload completed',
+          detail,
         )
         await loadEntries(currentPath)
       }
     } catch (uploadError) {
       toast.error(language === 'zh' ? '上传失败' : 'Upload failed', uploadError instanceof Error ? uploadError.message : String(uploadError))
+    } finally {
+      setUploading(false)
     }
-  }, [currentPath, language, loadEntries, server])
+  }, [currentPath, downloading, language, loadEntries, server, uploading])
 
   const handleDownload = useCallback(async (entry: RemoteFileEntry) => {
-    if (downloading) return
+    if (downloading || uploading) return
     setDownloading(true)
     try {
       const result = await api.remoteShell.download(server, entry.path)
@@ -274,7 +285,7 @@ export function RemoteFileBrowser({ server, language, onClose }: RemoteFileBrows
     } finally {
       setDownloading(false)
     }
-  }, [downloading, language, server])
+  }, [downloading, language, server, uploading])
 
   const pathSegments = useMemo(() => {
     const normalized = normalizePath(currentPath)
@@ -327,7 +338,8 @@ export function RemoteFileBrowser({ server, language, onClose }: RemoteFileBrows
         <div className="flex flex-wrap gap-2">
           <Button variant="ghost" size="sm" onClick={() => loadEntries(currentPath)} leftIcon={<RefreshCw className="h-4 w-4" />}>{language === 'zh' ? '刷新' : 'Refresh'}</Button>
           <Button variant="ghost" size="sm" onClick={() => loadEntries(getParentPath(currentPath))}>{language === 'zh' ? '上级目录' : 'Up'}</Button>
-          <Button variant="ghost" size="sm" onClick={handleUpload} leftIcon={<Upload className="h-4 w-4" />}>{language === 'zh' ? '上传文件' : 'Upload'}</Button>
+          <Button variant="ghost" size="sm" disabled={uploading || downloading} onClick={() => handleUpload('files')} leftIcon={<Upload className="h-4 w-4" />}>{uploading ? (language === 'zh' ? '上传中…' : 'Uploading…') : (language === 'zh' ? '上传文件' : 'Upload files')}</Button>
+          <Button variant="ghost" size="sm" disabled={uploading || downloading} onClick={() => handleUpload('directory')} leftIcon={<FolderUp className="h-4 w-4" />}>{language === 'zh' ? '上传目录' : 'Upload folder'}</Button>
           <Button variant="ghost" size="sm" onClick={handleCreateFolder} leftIcon={<FolderPlus className="h-4 w-4" />}>{language === 'zh' ? '新建目录' : 'New folder'}</Button>
           <Button variant="ghost" size="sm" onClick={handleCreateFile} leftIcon={<FileText className="h-4 w-4" />}>{language === 'zh' ? '新建文件' : 'New file'}</Button>
         </div>
@@ -350,7 +362,7 @@ export function RemoteFileBrowser({ server, language, onClose }: RemoteFileBrows
                 <Button
                   variant="ghost"
                   size="icon"
-                  disabled={downloading}
+                  disabled={downloading || uploading}
                   onClick={() => handleDownload(entry)}
                   title={
                     downloading
@@ -382,7 +394,7 @@ export function RemoteFileBrowser({ server, language, onClose }: RemoteFileBrows
           <div className="flex items-center justify-between gap-2">
             <Input value={selectedFilePath} readOnly className="text-xs" />
             <div className="flex items-center gap-2">
-              <Button variant="ghost" size="sm" disabled={downloading} onClick={() => handleDownload({ name: selectedFilePath.split('/').pop() || selectedFilePath, path: selectedFilePath, isDirectory: false, size: selectedFileContent.length })} leftIcon={<Download className="h-4 w-4" />}>{downloading ? (language === 'zh' ? '下载中…' : 'Downloading…') : (language === 'zh' ? '下载' : 'Download')}</Button>
+              <Button variant="ghost" size="sm" disabled={downloading || uploading} onClick={() => handleDownload({ name: selectedFilePath.split('/').pop() || selectedFilePath, path: selectedFilePath, isDirectory: false, size: selectedFileContent.length })} leftIcon={<Download className="h-4 w-4" />}>{downloading ? (language === 'zh' ? '下载中…' : 'Downloading…') : (language === 'zh' ? '下载' : 'Download')}</Button>
               <Button variant="ghost" size="sm" onClick={() => void openInEditor(selectedFilePath)} leftIcon={<SquareArrowOutUpRight className="h-4 w-4" />}>{language === 'zh' ? '打开到编辑器' : 'Open in editor'}</Button>
               <Button variant="primary" size="sm" onClick={saveFile} disabled={saving || !dirty} leftIcon={<Save className="h-4 w-4" />}>{saving ? (language === 'zh' ? '保存中…' : 'Saving…') : (language === 'zh' ? '保存' : 'Save')}</Button>
             </div>

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -216,7 +216,12 @@ export interface RemoteShellServer {
 export interface RemoteShellUploadResult {
   canceled: boolean
   uploaded: string[]
+  uploadedCount?: number
+  skippedSymlinks?: number
+  isDirectory?: boolean
 }
+
+export type RemoteShellUploadMode = 'files' | 'directory'
 
 export interface RemoteShellDownloadResult {
   canceled: boolean
@@ -512,7 +517,7 @@ export interface ElectronAPI {
   remoteShellRename: (server: RemoteShellServer, oldPath: string, newPath: string) => Promise<boolean>
   remoteShellDelete: (server: RemoteShellServer, remotePath: string) => Promise<boolean>
   remoteShellTestConnection: (server: RemoteShellServer) => Promise<{ success: boolean; error?: string }>
-  remoteShellUpload: (server: RemoteShellServer, remoteDirectory: string) => Promise<RemoteShellUploadResult>
+  remoteShellUpload: (server: RemoteShellServer, remoteDirectory: string, mode?: RemoteShellUploadMode) => Promise<RemoteShellUploadResult>
   remoteShellDownload: (server: RemoteShellServer, remotePath: string) => Promise<RemoteShellDownloadResult>
   remoteHostTrustGetStatus: (server: RemoteShellServer) => Promise<{ known: boolean; fingerprintSha256?: string }>
   remoteHostTrustGetLastDecision: (server: RemoteShellServer) => Promise<RemoteHostTrustDecision | null>

--- a/src/shared/config/tools.ts
+++ b/src/shared/config/tools.ts
@@ -613,10 +613,12 @@ For long-running servers or watch tasks:
     upload_to_remote: {
         name: 'upload_to_remote',
         displayName: 'Upload To Remote',
-        description: 'Open the native file picker and upload one or more local files to a remote directory. Requires approval.',
-        detailedDescription: `Upload local files to a remote directory.
+        description: 'Open the native picker and upload local files or a folder to a remote directory. Requires approval.',
+        detailedDescription: `Upload local files or a directory to a remote directory.
 - Requires dangerous approval
-- Opens the desktop file picker for the user to choose local files
+- mode=files (default): multi-file picker
+- mode=directory: folder picker; uploads recursively as <remote>/<folder-name>/
+- Symlinks and special files inside folders are skipped
 - Uses remote SFTP only
 - Never writes into the local workspace on fallback`,
         category: 'write',
@@ -631,6 +633,7 @@ For long-running servers or watch tasks:
         enabled: true,
         parameters: {
             path: { type: 'string', description: 'Remote destination directory. Defaults to the server remotePath or "." when omitted.', default: '.' },
+            mode: { type: 'string', description: 'Upload mode: "files" (default) or "directory".', enum: ['files', 'directory'], default: 'files' },
             server_name: { type: 'string', description: 'Optional Shell Studio remote server name.' },
         },
     },

--- a/src/shared/utils/remoteDownloadPath.ts
+++ b/src/shared/utils/remoteDownloadPath.ts
@@ -1,10 +1,16 @@
 import path from 'path'
 
-/** Max files/directories entries processed in one remote directory download. */
-export const REMOTE_DIR_DOWNLOAD_MAX_ENTRIES = 5000
+/** Max entries processed in one remote directory transfer (upload or download). */
+export const REMOTE_DIR_TRANSFER_MAX_ENTRIES = 5000
 
-/** Max nesting depth for remote directory downloads. */
-export const REMOTE_DIR_DOWNLOAD_MAX_DEPTH = 40
+/** Max nesting depth for remote directory transfers. */
+export const REMOTE_DIR_TRANSFER_MAX_DEPTH = 40
+
+/** @deprecated Prefer REMOTE_DIR_TRANSFER_MAX_ENTRIES */
+export const REMOTE_DIR_DOWNLOAD_MAX_ENTRIES = REMOTE_DIR_TRANSFER_MAX_ENTRIES
+
+/** @deprecated Prefer REMOTE_DIR_TRANSFER_MAX_DEPTH */
+export const REMOTE_DIR_DOWNLOAD_MAX_DEPTH = REMOTE_DIR_TRANSFER_MAX_DEPTH
 
 /**
  * Local folder that will receive a remote directory tree:
@@ -16,6 +22,15 @@ export function buildDirectoryDownloadTarget(selectedParentDir: string, remoteDi
   return path.join(parent, baseName)
 }
 
+/** Remote destination for a local directory upload: `<remoteParent>/<localDirBasename>`. */
+export function buildDirectoryUploadRemoteTarget(remoteParentDir: string, localDirectoryPath: string): string {
+  const baseName = assertSafeRemoteName(path.basename(path.resolve(localDirectoryPath)))
+  if (!remoteParentDir || remoteParentDir === '.') return baseName
+  if (remoteParentDir === '/') return `/${baseName}`
+  const parent = remoteParentDir.replace(/\\/g, '/').replace(/\/+$/, '')
+  return `${parent}/${baseName}`
+}
+
 export function remoteDirectoryBasename(remoteDirectoryPath: string): string {
   const normalized = remoteDirectoryPath.replace(/\\/g, '/').replace(/\/+$/, '')
   if (!normalized || normalized === '/' || normalized === '.') return 'remote-download'
@@ -23,11 +38,12 @@ export function remoteDirectoryBasename(remoteDirectoryPath: string): string {
   return parts[parts.length - 1] || 'remote-download'
 }
 
-/** Reject unsafe single path segments (no traversal, no separators). */
+/** Reject unsafe single path segments (no traversal, no separators, no padding). */
 export function assertSafeRemoteName(name: string): string {
   const trimmed = name.trim()
   if (
     !trimmed
+    || trimmed !== name
     || trimmed === '.'
     || trimmed === '..'
     || trimmed.includes('/')

--- a/tests/unit/shared/utils/remoteDownloadPath.test.ts
+++ b/tests/unit/shared/utils/remoteDownloadPath.test.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import {
   assertSafeRemoteName,
   buildDirectoryDownloadTarget,
+  buildDirectoryUploadRemoteTarget,
   isSftpSymbolicLinkMode,
   remoteDirectoryBasename,
   safeJoinUnderDownloadRoot,
@@ -17,9 +18,16 @@ describe('remoteDownloadPath', () => {
     expect(remoteDirectoryBasename('/var/log/')).toBe('log')
   })
 
+  it('builds a remote upload target from the local basename', () => {
+    expect(buildDirectoryUploadRemoteTarget('/var/www', '/tmp/my-app')).toBe('/var/www/my-app')
+    expect(buildDirectoryUploadRemoteTarget('.', '/tmp/my-app')).toBe('my-app')
+    expect(buildDirectoryUploadRemoteTarget('/', '/tmp/my-app')).toBe('/my-app')
+  })
+
   it('rejects unsafe remote names and path escapes', () => {
     expect(() => assertSafeRemoteName('..')).toThrow(/Unsafe/)
     expect(() => assertSafeRemoteName('a/b')).toThrow(/Unsafe/)
+    expect(() => assertSafeRemoteName(' padded ')).toThrow(/Unsafe/)
     expect(() => safeJoinUnderDownloadRoot('/tmp/out', '..')).toThrow()
     expect(safeJoinUnderDownloadRoot('/tmp/out', 'src', 'main.ts')).toBe(
       path.join('/tmp/out', 'src', 'main.ts'),


### PR DESCRIPTION
- Updated the ElectronAPI to support uploading both files and directories, allowing users to specify the upload mode.
- Enhanced the remoteShell module to handle directory uploads recursively, including tracking uploaded files and skipped symlinks.
- Improved the RemoteFileBrowser component to provide user feedback during uploads and handle different upload modes.
- Added utility functions for building remote upload paths and managing upload statistics.
- Updated relevant tests to ensure new upload functionality is covered and behaves as expected.
